### PR TITLE
Refactor ragged rows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ npm-debug.log
 debug.log
 bower_components/
 node_modules/
-fixtures/
 .idea/
 packages/
 

--- a/app/comma-chameleon/hot.js
+++ b/app/comma-chameleon/hot.js
@@ -27,7 +27,8 @@ ipc.on('loadData', function(data) {
   try {
     csv = $.csv.toArrays(data);
     hot.loadData(csv);
-    fixRaggedRows(csv);
+    var proceed = confirmRaggedRows(csv) === undefined ? false : confirmRaggedRows(csv); // assign to false for when window opens or dud file loads
+    if(proceed["ragged"] && prompt_consent()){fixRaggedRows(csv, proceed["resume"]);}
   } catch(e) {
     alert('An error has occurred: '+e.message)
   }

--- a/app/comma-chameleon/hot.js
+++ b/app/comma-chameleon/hot.js
@@ -1,6 +1,6 @@
 var ipc = require('ipc');
 var fs = require('fs');
-var validationNotes = require('../validation_notes.json')
+var validationNotes = require('../validation_notes.json');
 
 var container = document.getElementById("editor");
 var hot = new Handsontable(container, {

--- a/app/comma-chameleon/hot.js
+++ b/app/comma-chameleon/hot.js
@@ -23,12 +23,18 @@ container.addEventListener('contextmenu', function (e) {
   columnLeft.enabled = true
 }, false);
 
+function prompt_consent(){
+  return confirm("Your file has ragged rows, do you want to correct this?");
+}
+
 ipc.on('loadData', function(data) {
   try {
     csv = $.csv.toArrays(data);
     hot.loadData(csv);
-    var proceed = confirmRaggedRows(csv) === undefined ? false : confirmRaggedRows(csv); // assign to false for when window opens or dud file loads
+    var proceed = confirmRaggedRows(csv) === undefined ? false : confirmRaggedRows(csv);
+    // assign to false for when window opens or dud file loads
     if(proceed["ragged"] && prompt_consent()){fixRaggedRows(csv, proceed["resume"]);}
+    // TODO maybe too terse? resume attribute is employed so that any time taken in reading a CSV is not duplicated in second loop
   } catch(e) {
     alert('An error has occurred: '+e.message)
   }

--- a/app/comma-chameleon/ragged-rows.js
+++ b/app/comma-chameleon/ragged-rows.js
@@ -2,25 +2,11 @@
 
 ipc.on('ragged_rows', function() {
   csv = hot.getData();
-  //var confirmation = confirmRaggedRows(csv);
-  //if(confirmation["ragged"] && prompt()){
-  //  //fixRaggedRows();
-  //}
-  //console.log(confirmation["ragged"]);
-  //console.log(confirmRaggedRows(csv)["ragged"]);
-  //if(confirmRaggedRows(csv)["ragged"] && prompt()){
-  //  console.log("conulted baybee");
-  //}
-  //console.log(Object.getOwnPropertyNames(confirmRaggedRows(csv)));
   fixRaggedRows(csv);
 });
 
 // Fills undefined cells with an empty string, keeping the table in a
 // rectangular format
-
-//function gogo(){
-//  if(confirmRaggedRows(csv))
-//}
 
 function confirmRaggedRows(csv_sheet){
   var ragged_rows = false;
@@ -36,25 +22,22 @@ function confirmRaggedRows(csv_sheet){
   }
 }
 
-function prompt_consent(){
-  return confirm("Your file has ragged rows, do you want to correct this?");
-}
-
-function fixRaggedRows(csv_sheet, kwa) {
+function fixRaggedRows(csv_sheet, row) {
   var $messagePanel = $('#message-panel');
   var ragged_rows = 0;
-  var y = kwa === undefined ? 0 : kwa;
+  var y = row === undefined ? 0 : row;
   // eval to left of colon if true and right of colon if false
 
   for (y; y < csv_sheet.length; y++) {
     for (var x = 0; x < getMaxColumns(csv_sheet); x++) {
       if (hot.getDataAtCell(y,x) === undefined) {
+        fixCell(csv_sheet,y,x);
+        var amendment = logChanges(x,y);
         $('#right-panel').removeClass("hidden");
-        $messagePanel.append('<p>' + fixCell(csv_sheet,y,x) + '<p>')
+        $messagePanel.append('<p>' + amendment + '<p>')
       }
     }
   }
-
   updateTable(csv_sheet);
 }
 
@@ -71,8 +54,10 @@ function getMaxColumns(csv_array) {
 
 function fixCell(csv_array,y,x) {
   csv_array[y].push("")
+}
+
+function logChanges(x,y){
   var logMsg = "Cell (" + String.fromCharCode(97 + x).toUpperCase() + "," + (y + 1) + ") has been added to file"
-  //console.log(logMsg)
   return logMsg
 }
 

--- a/app/comma-chameleon/ragged-rows.js
+++ b/app/comma-chameleon/ragged-rows.js
@@ -23,18 +23,16 @@ function confirmRaggedRows(csv_sheet){
 }
 
 function fixRaggedRows(csv_sheet, row) {
-  var $messagePanel = $('#message-panel');
-  var ragged_rows = 0;
+
   var y = row === undefined ? 0 : row;
   // eval to left of colon if true and right of colon if false
 
   for (y; y < csv_sheet.length; y++) {
     for (var x = 0; x < getMaxColumns(csv_sheet); x++) {
       if (hot.getDataAtCell(y,x) === undefined) {
+        $('#right-panel').removeClass("hidden")
         fixCell(csv_sheet,y,x);
-        var amendment = logChanges(x,y);
-        $('#right-panel').removeClass("hidden");
-        $messagePanel.append('<p>' + amendment + '<p>')
+        logChanges(x,y);
       }
     }
   }
@@ -53,11 +51,14 @@ function getMaxColumns(csv_array) {
 }
 
 function fixCell(csv_array,row) {
-  csv_array[row].push("")
+  csv_array[row].push("");
 }
 
 function logChanges(col,row){
-  var logMsg = "Cell (" + String.fromCharCode(97 + col).toUpperCase() + "," + (row + 1) + ") has been added to file"
+
+  var logMsg = "Cell (" + String.fromCharCode(97 + col).toUpperCase() + "," + (row + 1) + ") has been added to file";
+  var $messagePanel = $('#message-panel');
+  $messagePanel.append('<p>' + logMsg + '<p>');
   return logMsg
 }
 

--- a/app/comma-chameleon/ragged-rows.js
+++ b/app/comma-chameleon/ragged-rows.js
@@ -44,7 +44,7 @@ function fixRaggedRows(csv_sheet, row) {
 function getMaxColumns(csv_array) {
   var max_columns = 0
   for (var i = 0; i < csv_array.length; i++) {
-    var col_length = csv_array[i].length
+    var col_length = csv_array[i].length;
     if (col_length > max_columns) {
       max_columns = col_length
     }
@@ -52,17 +52,17 @@ function getMaxColumns(csv_array) {
   return max_columns
 }
 
-function fixCell(csv_array,y,x) {
-  csv_array[y].push("")
+function fixCell(csv_array,row) {
+  csv_array[row].push("")
 }
 
-function logChanges(x,y){
-  var logMsg = "Cell (" + String.fromCharCode(97 + x).toUpperCase() + "," + (y + 1) + ") has been added to file"
+function logChanges(col,row){
+  var logMsg = "Cell (" + String.fromCharCode(97 + col).toUpperCase() + "," + (row + 1) + ") has been added to file"
   return logMsg
 }
 
 function updateTable(csv_array) {
   hot.updateSettings ({
-    data: csv_array,
+    data: csv_array
   });
 }

--- a/app/comma-chameleon/ragged-rows.js
+++ b/app/comma-chameleon/ragged-rows.js
@@ -1,12 +1,41 @@
+'use strict'
+
 ipc.on('ragged_rows', function() {
   csv = hot.getData();
   fixRaggedRows(csv);
 });
 
+// Fills undefined cells with an empty string, keeping the table in a
+// rectangular format
+
+function fixRaggedRows(csv_sheet) {
+  var $messagePanel = $('#message-panel');
+  var ragged_rows = 0;
+  //
+  for (var y = 0; y < csv_sheet.length; y++) {
+    for (var x = 0; x < getMaxColumns(csv_sheet); x++) {
+      if (hot.getDataAtCell(y,x) === undefined) {
+        if (ragged_rows == 0) {
+          if (confirm("Your file has ragged rows, do you want to correct this?")) {
+            $('#right-panel').removeClass("hidden")
+            ragged_rows = 1
+            $messagePanel.append('<p>' + fixCell(csv_sheet,y,x) + '<p>')
+          }
+          else {ragged_rows = -1}
+        }
+        else if (ragged_rows == 1) {
+          $messagePanel.append('<p>' + fixCell(csv_sheet,y,x) + '<p>')
+        }
+      }
+    }
+  }
+  updateTable(csv_sheet)
+}
+
 function getMaxColumns(csv_array) {
-  max_columns = 0
+  var max_columns = 0
   for (var i = 0; i < csv_array.length; i++) {
-    col_length = csv_array[i].length
+    var col_length = csv_array[i].length
     if (col_length > max_columns) {
       max_columns = col_length
     }
@@ -14,36 +43,9 @@ function getMaxColumns(csv_array) {
   return max_columns
 }
 
-// Fills undefined cells with an empty string, keeping the table in a
-// rectangular format
-
-function fixRaggedRows(csv_array) {
-  var $messagePanel = $('#message-panel');
-  ragged_rows = 0;
-  //
-  for (var y = 0; y < csv_array.length; y++) {
-    for (var x = 0; x < getMaxColumns(csv_array); x++) {
-      if (hot.getDataAtCell(y,x) === undefined) {
-        if (ragged_rows == 0) {
-          if (confirm("Your file has ragged rows, do you want to correct this?")) {
-            $('#right-panel').removeClass("hidden")
-            ragged_rows = 1
-            $messagePanel.append('<p>' + fixCell(csv_array,y,x) + '<p>')
-          }
-          else {ragged_rows = -1}
-        }
-        else if (ragged_rows == 1) {
-          $messagePanel.append('<p>' + fixCell(csv_array,y,x) + '<p>')
-        }
-      }
-    }
-  }
-  updateTable(csv_array)
-}
-
 function fixCell(csv_array,y,x) {
   csv_array[y].push("")
-  logMsg = "Cell (" + String.fromCharCode(97 + x).toUpperCase() + "," + (y + 1) + ") has been added to file"
+  var logMsg = "Cell (" + String.fromCharCode(97 + x).toUpperCase() + "," + (y + 1) + ") has been added to file"
   console.log(logMsg)
   return logMsg
 }

--- a/app/comma-chameleon/ragged-rows.js
+++ b/app/comma-chameleon/ragged-rows.js
@@ -2,34 +2,60 @@
 
 ipc.on('ragged_rows', function() {
   csv = hot.getData();
+  //var confirmation = confirmRaggedRows(csv);
+  //if(confirmation["ragged"] && prompt()){
+  //  //fixRaggedRows();
+  //}
+  //console.log(confirmation["ragged"]);
+  //console.log(confirmRaggedRows(csv)["ragged"]);
+  //if(confirmRaggedRows(csv)["ragged"] && prompt()){
+  //  console.log("conulted baybee");
+  //}
+  //console.log(Object.getOwnPropertyNames(confirmRaggedRows(csv)));
   fixRaggedRows(csv);
 });
 
 // Fills undefined cells with an empty string, keeping the table in a
 // rectangular format
 
-function fixRaggedRows(csv_sheet) {
-  var $messagePanel = $('#message-panel');
-  var ragged_rows = 0;
-  //
+//function gogo(){
+//  if(confirmRaggedRows(csv))
+//}
+
+function confirmRaggedRows(csv_sheet){
+  var ragged_rows = false;
+  var resume = 0;
   for (var y = 0; y < csv_sheet.length; y++) {
     for (var x = 0; x < getMaxColumns(csv_sheet); x++) {
       if (hot.getDataAtCell(y,x) === undefined) {
-        if (ragged_rows == 0) {
-          if (confirm("Your file has ragged rows, do you want to correct this?")) {
-            $('#right-panel').removeClass("hidden")
-            ragged_rows = 1
-            $messagePanel.append('<p>' + fixCell(csv_sheet,y,x) + '<p>')
-          }
-          else {ragged_rows = -1}
-        }
-        else if (ragged_rows == 1) {
-          $messagePanel.append('<p>' + fixCell(csv_sheet,y,x) + '<p>')
-        }
+        ragged_rows = true;
+        resume = y;
+        return({ragged: ragged_rows, resume: y});
       }
     }
   }
-  updateTable(csv_sheet)
+}
+
+function prompt_consent(){
+  return confirm("Your file has ragged rows, do you want to correct this?");
+}
+
+function fixRaggedRows(csv_sheet, kwa) {
+  var $messagePanel = $('#message-panel');
+  var ragged_rows = 0;
+  var y = kwa === undefined ? 0 : kwa;
+  // eval to left of colon if true and right of colon if false
+
+  for (y; y < csv_sheet.length; y++) {
+    for (var x = 0; x < getMaxColumns(csv_sheet); x++) {
+      if (hot.getDataAtCell(y,x) === undefined) {
+        $('#right-panel').removeClass("hidden");
+        $messagePanel.append('<p>' + fixCell(csv_sheet,y,x) + '<p>')
+      }
+    }
+  }
+
+  updateTable(csv_sheet);
 }
 
 function getMaxColumns(csv_array) {
@@ -46,7 +72,7 @@ function getMaxColumns(csv_array) {
 function fixCell(csv_array,y,x) {
   csv_array[y].push("")
   var logMsg = "Cell (" + String.fromCharCode(97 + x).toUpperCase() + "," + (y + 1) + ") has been added to file"
-  console.log(logMsg)
+  //console.log(logMsg)
   return logMsg
 }
 

--- a/fixtures/empty_cells.csv
+++ b/fixtures/empty_cells.csv
@@ -1,0 +1,6 @@
+firstname,lastname,status
+Sam,,Prawn
+Sam,Pikesley,Prawn
+James,,Clown
+Toast,Milk,Weak
+Weak,White,White

--- a/fixtures/ragged_rows.csv
+++ b/fixtures/ragged_rows.csv
@@ -1,0 +1,9 @@
+firstname,lastname,status
+Sam,Pikesley,Prawn
+Stuart,Harrison
+James,Smith,Clown
+
+Water,Ship
+Toast,Milk,Weak
+Weak,White,White
+Rain,Rain


### PR DESCRIPTION
this refactor is designed to make the methods as discreet as possible within ragged-rows
This will hopefully make any future 'view controller' separations more straightforward
Helps with making code more amenable to unit tests

TODO
`prompt_consent()` could probably live somewhere separate to both these files
Decision: when ragged_rows executes of `fixtures/ragged_rows.csv` it will fill entirely empty rows with String chars `""` - this might have impact on what is passed upstream to CSVlint
Maybe a separate issue but CSV parsing in this app seems to read empty rows as ",,", and infers two cells from it rather than 3 - this can be duplicated by uploaded `fixtures/ragged_rows.csv` and observing the reported errors - CELL A,5 is not amended
![screen shot 2015-09-16 at 17 18 44](https://cloud.githubusercontent.com/assets/1039017/9910845/1cb54b58-5c97-11e5-89d1-9b583a37b99f.png)
