### PR TITLE
Fix issue 110

### DIFF
--- a/main/datapackage.js
+++ b/main/datapackage.js
@@ -10,7 +10,7 @@ var path = require('path');
 var exportdata = function() {
   var window = BrowserWindow.getFocusedWindow();
 
-  datapackage = new BrowserWindow({width: 450, height: 600});
+  var datapackage = new BrowserWindow({width: 450, height: 600});
   datapackage.loadURL('file://' + __dirname + '/../views/datapackage.html');
 
   datapackage.on('closed', function() {


### PR DESCRIPTION
`datapackage` module was being overwritten with a `BrowserWindow` object and then `null` when the window was closed due to a scope error caused by missing `var` statement.
Closes #110