### PR TITLE
keyboard shortcut improvements

### DIFF
--- a/main.js
+++ b/main.js
@@ -18,6 +18,7 @@ global.excel = require('./main/excel')
 global.fileActions = require('./main/file')
 global.tools = require('./main/tools')
 global.validate = require('./main/validate')
+global.help = require('./main/help');
 
 require('electron-debug')({showDevTools: true})
 /*require('crash-reporter').start(

--- a/main/help.js
+++ b/main/help.js
@@ -1,0 +1,18 @@
+global.electron = require('electron');
+
+global.BrowserWindow = electron.BrowserWindow;
+global.Dialog = electron.dialog;
+
+var showKeyboardHelp = function() {
+
+  var showKeyboardHelp = new BrowserWindow({width: 600, height: 600});
+  showKeyboardHelp.loadURL('file://' + __dirname + '/../views/keyboard_help.html');
+
+  showKeyboardHelp.on('closed', function() {
+    showKeyboardHelp = null;
+  });
+};
+
+module.exports = {
+  showKeyboardHelp: showKeyboardHelp,
+};

--- a/main/menu.js
+++ b/main/menu.js
@@ -52,12 +52,12 @@ exports.menu = [
       },
       {
         label: 'Hide Comma Chameleon',
-        accelerator: 'Cmd+H',
+        accelerator: 'CmdOrCtrl+H',
         selector: 'hide:'
       },
       {
         label: 'Hide Others',
-        accelerator: 'Cmd+Shift+H',
+        accelerator: 'CmdOrCtrl+Shift+H',
         selector: 'hideOtherApplications:'
       },
       {
@@ -95,7 +95,6 @@ exports.menu = [
       },
       {
         label: 'Import Excel file',
-        accelerator: 'CmdOrCtrl+I',
         click: function() { excel.importExcel(); }
       },
       {
@@ -174,14 +173,14 @@ exports.menu = [
       },
       {
         label: 'Insert row above',
-        accelerator: 'Ctrl+K',
+        accelerator: 'CmdOrCtrl+I',
         click: function() {
           mainWindow.webContents.send('insertRowAbove');
         }
       },
       {
         label: 'Insert row below',
-        accelerator: 'Ctrl+J',
+        accelerator: 'CmdOrCtrl+K',
         click: function() {
           mainWindow.webContents.send('insertRowBelow');
         }
@@ -191,14 +190,14 @@ exports.menu = [
       },
       {
         label: 'Insert column left',
-        accelerator: 'Ctrl+H',
+        accelerator: 'CmdOrCtrl+J',
         click: function() {
           mainWindow.webContents.send('insertColumnLeft');
         }
       },
       {
         label: 'Insert column right',
-        accelerator: 'Ctrl+L',
+        accelerator: 'CmdOrCtrl+L',
         click: function() {
           mainWindow.webContents.send('insertColumnRight');
         }

--- a/main/menu.js
+++ b/main/menu.js
@@ -52,12 +52,12 @@ exports.menu = [
       },
       {
         label: 'Hide Comma Chameleon',
-        accelerator: 'CmdOrCtrl+H',
+        accelerator: 'Cmd+H',
         selector: 'hide:'
       },
       {
         label: 'Hide Others',
-        accelerator: 'CmdOrCtrl+Shift+H',
+        accelerator: 'Cmd+Shift+H',
         selector: 'hideOtherApplications:'
       },
       {
@@ -174,14 +174,14 @@ exports.menu = [
       },
       {
         label: 'Insert row above',
-        accelerator: 'Alt+K',
+        accelerator: 'Ctrl+K',
         click: function() {
           mainWindow.webContents.send('insertRowAbove');
         }
       },
       {
         label: 'Insert row below',
-        accelerator: 'Alt+J',
+        accelerator: 'Ctrl+J',
         click: function() {
           mainWindow.webContents.send('insertRowBelow');
         }
@@ -191,14 +191,14 @@ exports.menu = [
       },
       {
         label: 'Insert column left',
-        accelerator: 'Alt+H',
+        accelerator: 'Ctrl+H',
         click: function() {
           mainWindow.webContents.send('insertColumnLeft');
         }
       },
       {
         label: 'Insert column right',
-        accelerator: 'Alt+L',
+        accelerator: 'Ctrl+L',
         click: function() {
           mainWindow.webContents.send('insertColumnRight');
         }

--- a/main/menu.js
+++ b/main/menu.js
@@ -174,12 +174,14 @@ exports.menu = [
       },
       {
         label: 'Insert row above',
+        accelerator: 'Alt+W',
         click: function() {
           mainWindow.webContents.send('insertRowAbove');
         }
       },
       {
         label: 'Insert row below',
+        accelerator: 'Alt+S',
         click: function() {
           mainWindow.webContents.send('insertRowBelow');
         }
@@ -189,12 +191,14 @@ exports.menu = [
       },
       {
         label: 'Insert column left',
+        accelerator: 'Alt+A',
         click: function() {
           mainWindow.webContents.send('insertColumnLeft');
         }
       },
       {
         label: 'Insert column right',
+        accelerator: 'Alt+D',
         click: function() {
           mainWindow.webContents.send('insertColumnRight');
         }

--- a/main/menu.js
+++ b/main/menu.js
@@ -168,7 +168,52 @@ exports.menu = [
         label: 'Select All',
         accelerator: 'CmdOrCtrl+A',
         selector: 'selectAll:'
-      }
+      },
+      {
+        type: 'separator'
+      },
+      {
+        label: 'Insert row above',
+        click: function() {
+          mainWindow.webContents.send('insertRowAbove');
+        }
+      },
+      {
+        label: 'Insert row below',
+        click: function() {
+          mainWindow.webContents.send('insertRowBelow');
+        }
+      },
+      {
+        type: 'separator'
+      },
+      {
+        label: 'Insert column left',
+        click: function() {
+          mainWindow.webContents.send('insertColumnLeft');
+        }
+      },
+      {
+        label: 'Insert column right',
+        click: function() {
+          mainWindow.webContents.send('insertColumnRight');
+        }
+      },
+      {
+        type: 'separator'
+      },
+      {
+        label: 'Remove row(s)',
+        click: function() {
+          mainWindow.webContents.send('removeRows');
+        }
+      },
+      {
+        label: 'Remove column(s)',
+        click: function() {
+          mainWindow.webContents.send('removeColumns');
+        }
+      },
     ]
   },
   {

--- a/main/menu.js
+++ b/main/menu.js
@@ -174,14 +174,14 @@ exports.menu = [
       },
       {
         label: 'Insert row above',
-        accelerator: 'Alt+W',
+        accelerator: 'Alt+K',
         click: function() {
           mainWindow.webContents.send('insertRowAbove');
         }
       },
       {
         label: 'Insert row below',
-        accelerator: 'Alt+S',
+        accelerator: 'Alt+J',
         click: function() {
           mainWindow.webContents.send('insertRowBelow');
         }
@@ -191,14 +191,14 @@ exports.menu = [
       },
       {
         label: 'Insert column left',
-        accelerator: 'Alt+A',
+        accelerator: 'Alt+H',
         click: function() {
           mainWindow.webContents.send('insertColumnLeft');
         }
       },
       {
         label: 'Insert column right',
-        accelerator: 'Alt+D',
+        accelerator: 'Alt+L',
         click: function() {
           mainWindow.webContents.send('insertColumnRight');
         }

--- a/main/menu.js
+++ b/main/menu.js
@@ -276,6 +276,13 @@ exports.menu = [
   },
   {
     label: 'Help',
-    submenu: []
+    submenu: [
+      {
+        label: 'Editor Keyboard Shortcuts',
+        click: function() {
+          help.showKeyboardHelp();
+        }
+      }
+    ]
   }
 ];

--- a/renderer/hot.js
+++ b/renderer/hot.js
@@ -46,6 +46,7 @@ var initialise = function(container) {
 
 var insertRowAbove = function() {
   var range = hot.getSelectedRange();
+  if (typeof range === 'undefined') { return; }
   var start = Math.min(range.from.row, range.to.row);
   hot.alter('insert_row', start);
   hot.deselectCell();
@@ -53,6 +54,7 @@ var insertRowAbove = function() {
 
 var insertRowBelow = function() {
   var range = hot.getSelectedRange();
+  if (typeof range === 'undefined') { return; }
   var end = Math.max(range.from.row, range.to.row);
   hot.alter('insert_row', (end + 1));
   hot.deselectCell();
@@ -60,6 +62,7 @@ var insertRowBelow = function() {
 
 var insertColumnLeft = function() {
   var range = hot.getSelectedRange();
+  if (typeof range === 'undefined') { return; }
   var start = Math.min(range.from.col, range.to.col);
   hot.alter('insert_col', start);
   hot.deselectCell();
@@ -67,6 +70,7 @@ var insertColumnLeft = function() {
 
 var insertColumnRight = function() {
   var range = hot.getSelectedRange();
+  if (typeof range === 'undefined') { return; }
   var end = Math.max(range.from.col, range.to.col);
   hot.alter('insert_col', (end + 1));
   hot.deselectCell();
@@ -74,6 +78,7 @@ var insertColumnRight = function() {
 
 var removeRows = function() {
   var range = hot.getSelectedRange();
+  if (typeof range === 'undefined') { return; }
 
   var start = Math.min(range.from.row, range.to.row);
   var end   = Math.max(range.from.row, range.to.row);
@@ -89,6 +94,7 @@ var removeRows = function() {
 
 var removeColumns = function() {
   var range = hot.getSelectedRange();
+  if (typeof range === 'undefined') { return; }
 
   var start = Math.min(range.from.col, range.to.col);
   var end   = Math.max(range.from.col, range.to.col);

--- a/renderer/hot.js
+++ b/renderer/hot.js
@@ -45,6 +45,7 @@ var initialise = function(container) {
 };
 
 var insertRowAbove = function(deselect) {
+  hot.getActiveEditor().finishEditing(true);
   var range = hot.getSelectedRange();
   if (typeof range === 'undefined') { return; }
   var start = Math.min(range.from.row, range.to.row);
@@ -55,6 +56,7 @@ var insertRowAbove = function(deselect) {
 };
 
 var insertRowBelow = function(deselect) {
+  hot.getActiveEditor().finishEditing(true);
   var range = hot.getSelectedRange();
   if (typeof range === 'undefined') { return; }
   var end = Math.max(range.from.row, range.to.row);
@@ -65,6 +67,7 @@ var insertRowBelow = function(deselect) {
 };
 
 var insertColumnLeft = function(deselect) {
+  hot.getActiveEditor().finishEditing(true);
   var range = hot.getSelectedRange();
   if (typeof range === 'undefined') { return; }
   var start = Math.min(range.from.col, range.to.col);
@@ -75,6 +78,7 @@ var insertColumnLeft = function(deselect) {
 };
 
 var insertColumnRight = function(deselect) {
+  hot.getActiveEditor().finishEditing(true);
   var range = hot.getSelectedRange();
   if (typeof range === 'undefined') { return; }
   var end = Math.max(range.from.col, range.to.col);

--- a/renderer/hot.js
+++ b/renderer/hot.js
@@ -44,7 +44,71 @@ var initialise = function(container) {
   return hot;
 };
 
+var insertRowAbove = function() {
+  var range = hot.getSelectedRange();
+  var start = Math.min(range.from.row, range.to.row);
+  hot.alter('insert_row', start);
+  hot.deselectCell();
+};
+
+var insertRowBelow = function() {
+  var range = hot.getSelectedRange();
+  var end = Math.max(range.from.row, range.to.row);
+  hot.alter('insert_row', (end + 1));
+  hot.deselectCell();
+};
+
+var insertColumnLeft = function() {
+  var range = hot.getSelectedRange();
+  var start = Math.min(range.from.col, range.to.col);
+  hot.alter('insert_col', start);
+  hot.deselectCell();
+};
+
+var insertColumnRight = function() {
+  var range = hot.getSelectedRange();
+  var end = Math.max(range.from.col, range.to.col);
+  hot.alter('insert_col', (end + 1));
+  hot.deselectCell();
+};
+
+var removeRows = function() {
+  var range = hot.getSelectedRange();
+
+  var start = Math.min(range.from.row, range.to.row);
+  var end   = Math.max(range.from.row, range.to.row);
+
+  for (var row = start; row <= end; row++) {
+    // rows are re-indexed after each remove
+    // so always remove 'start'
+    hot.alter('remove_row', start);
+  }
+
+  hot.deselectCell();
+};
+
+var removeColumns = function() {
+  var range = hot.getSelectedRange();
+
+  var start = Math.min(range.from.col, range.to.col);
+  var end   = Math.max(range.from.col, range.to.col);
+
+  for (var col = start; col <= end; col++) {
+    // cols are re-indexed after each remove
+    // so always remove 'start'
+    hot.alter('remove_col', start);
+  }
+
+  hot.deselectCell();
+};
+
 module.exports = {
+  insertRowAbove: insertRowAbove,
+  insertRowBelow: insertRowBelow,
+  insertColumnLeft: insertColumnLeft,
+  insertColumnRight: insertColumnRight,
+  removeRows: removeRows,
+  removeColumns: removeColumns,
   create: initialise,
   // returns the HoT object
-}
+};

--- a/renderer/hot.js
+++ b/renderer/hot.js
@@ -44,36 +44,44 @@ var initialise = function(container) {
   return hot;
 };
 
-var insertRowAbove = function() {
+var insertRowAbove = function(deselect) {
   var range = hot.getSelectedRange();
   if (typeof range === 'undefined') { return; }
   var start = Math.min(range.from.row, range.to.row);
   hot.alter('insert_row', start);
-  hot.deselectCell();
+  if (deselect) {
+    hot.deselectCell();
+  }
 };
 
-var insertRowBelow = function() {
+var insertRowBelow = function(deselect) {
   var range = hot.getSelectedRange();
   if (typeof range === 'undefined') { return; }
   var end = Math.max(range.from.row, range.to.row);
   hot.alter('insert_row', (end + 1));
-  hot.deselectCell();
+  if (deselect) {
+    hot.deselectCell();
+  }
 };
 
-var insertColumnLeft = function() {
+var insertColumnLeft = function(deselect) {
   var range = hot.getSelectedRange();
   if (typeof range === 'undefined') { return; }
   var start = Math.min(range.from.col, range.to.col);
   hot.alter('insert_col', start);
-  hot.deselectCell();
+  if (deselect) {
+    hot.deselectCell();
+  }
 };
 
-var insertColumnRight = function() {
+var insertColumnRight = function(deselect) {
   var range = hot.getSelectedRange();
   if (typeof range === 'undefined') { return; }
   var end = Math.max(range.from.col, range.to.col);
   hot.alter('insert_col', (end + 1));
-  hot.deselectCell();
+  if (deselect) {
+    hot.deselectCell();
+  }
 };
 
 var removeRows = function() {

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -102,19 +102,19 @@ ipc.on('validationResults', function(e, results) {
 });
 
 ipc.on('insertRowAbove', function() {
-  hotController.insertRowAbove();
+  hotController.insertRowAbove(false);
 });
 
 ipc.on('insertRowBelow', function() {
-  hotController.insertRowBelow();
+  hotController.insertRowBelow(false);
 });
 
 ipc.on('insertColumnLeft', function() {
-  hotController.insertColumnLeft();
+  hotController.insertColumnLeft(false);
 });
 
 ipc.on('insertColumnRight', function() {
-  hotController.insertColumnRight();
+  hotController.insertColumnRight(false);
 });
 
 ipc.on('removeRows', function() {

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -100,3 +100,27 @@ ipc.on('validationStarted', function() {
 ipc.on('validationResults', function(e, results) {
   validation.displayResults(results);
 });
+
+ipc.on('insertRowAbove', function() {
+  hotController.insertRowAbove();
+});
+
+ipc.on('insertRowBelow', function() {
+  hotController.insertRowBelow();
+});
+
+ipc.on('insertColumnLeft', function() {
+  hotController.insertColumnLeft();
+});
+
+ipc.on('insertColumnRight', function() {
+  hotController.insertColumnRight();
+});
+
+ipc.on('removeRows', function() {
+  hotController.removeRows();
+});
+
+ipc.on('removeColumns', function() {
+  hotController.removeColumns();
+});

--- a/renderer/menu.js
+++ b/renderer/menu.js
@@ -1,3 +1,5 @@
+var hotController = require('../renderer/hot.js');
+
 const {remote} = require('electron');
 const {Menu, MenuItem} = remote;
 
@@ -6,76 +8,42 @@ var menu = new Menu();
 var rowAbove = new MenuItem({
   label: 'Insert row above',
   click: function() {
-    var range = hot.getSelectedRange();
-    var start = Math.min(range.from.row, range.to.row);
-    hot.alter('insert_row', start);
-    hot.deselectCell();
+    hotController.insertRowAbove();
   }
 });
 
 var rowBelow = new MenuItem({
   label: 'Insert row below',
   click: function() {
-    var range = hot.getSelectedRange();
-    var end = Math.max(range.from.row, range.to.row);
-    hot.alter('insert_row', (end + 1));
-    hot.deselectCell();
+    hotController.insertRowBelow();
   }
 });
 
 var columnLeft = new MenuItem({
   label: 'Insert column left',
   click: function() {
-    var range = hot.getSelectedRange();
-    var start = Math.min(range.from.col, range.to.col);
-    hot.alter('insert_col', start);
-    hot.deselectCell();
+    hotController.insertColumnLeft();
   }
 });
 
 var columnRight = new MenuItem({
   label: 'Insert column right',
   click: function() {
-    var range = hot.getSelectedRange();
-    var end = Math.max(range.from.col, range.to.col);
-    hot.alter('insert_col', (end + 1));
-    hot.deselectCell();
+    hotController.insertColumnRight();
   }
 });
 
 var removeRow = new MenuItem({
   label: 'Remove row(s)',
   click: function() {
-    var range = hot.getSelectedRange();
-
-    var start = Math.min(range.from.row, range.to.row);
-    var end   = Math.max(range.from.row, range.to.row);
-
-    for (var row = start; row <= end; row++) {
-      // rows are re-indexed after each remove
-      // so always remove 'start'
-      hot.alter('remove_row', start);
-    }
-
-    hot.deselectCell();
+    hotController.removeRows();
   }
 });
 
 var removeCol = new MenuItem({
   label: 'Remove column(s)',
   click: function() {
-    var range = hot.getSelectedRange();
-
-    var start = Math.min(range.from.col, range.to.col);
-    var end   = Math.max(range.from.col, range.to.col);
-
-    for (var col = start; col <= end; col++) {
-      // cols are re-indexed after each remove
-      // so always remove 'start'
-      hot.alter('remove_col', start);
-    }
-
-    hot.deselectCell();
+    hotController.removeColumns();
   }
 });
 

--- a/renderer/menu.js
+++ b/renderer/menu.js
@@ -8,28 +8,28 @@ var menu = new Menu();
 var rowAbove = new MenuItem({
   label: 'Insert row above',
   click: function() {
-    hotController.insertRowAbove();
+    hotController.insertRowAbove(true);
   }
 });
 
 var rowBelow = new MenuItem({
   label: 'Insert row below',
   click: function() {
-    hotController.insertRowBelow();
+    hotController.insertRowBelow(true);
   }
 });
 
 var columnLeft = new MenuItem({
   label: 'Insert column left',
   click: function() {
-    hotController.insertColumnLeft();
+    hotController.insertColumnLeft(true);
   }
 });
 
 var columnRight = new MenuItem({
   label: 'Insert column right',
   click: function() {
-    hotController.insertColumnRight();
+    hotController.insertColumnRight(true);
   }
 });
 

--- a/views/views-content/keyboard_help.html
+++ b/views/views-content/keyboard_help.html
@@ -73,7 +73,10 @@
     <h2>Editing</h2>
     <ul>
         <li>
-            <kbd>Enter</kbd> – open/close cell editor
+            <kbd>Enter</kbd> – insert row below (if in bottom row)
+        </li>
+        <li>
+            <kbd>Tab</kbd> – insert column right (if in rightmost column)
         </li>
         <li>
             <kbd>F2</kbd> – open cell editor

--- a/views/views-content/keyboard_help.html
+++ b/views/views-content/keyboard_help.html
@@ -1,0 +1,123 @@
+{{#extend "layout" pageTitle="Editor Keyboard Shortcuts" containerClass="container-fluid"}}
+
+  {{#content "head" mode="append"}}
+    <meta charset="UTF-8">
+  {{/content}}
+
+
+  {{#content "body"}}
+    <h1>Editor Keyboard Shortcuts</h1>
+    <h2>Navigation</h2>
+    <ul>
+        <li>
+            <kbd>Arrow Up ↑</kbd>    – move to the cell above current active cell (if exists)
+        </li>
+        <li>
+            <kbd>Arrow Down ↓</kbd>  – move to cell underneath current active cell (if exists)
+        </li>
+        <li>
+            <kbd>Arrow Right →</kbd> – move to the cell on the right side of the current active cell (if exists)
+        </li>
+        <li>
+            <kbd>Arrow Left ←</kbd>  – move to the cell on the left side of current active cell (if exists)
+        </li>
+        <li>
+            <kbd>Tab</kbd>         – move to the cell on the right side of the current active cell (if exists)
+        </li>
+        <li>
+            <kbd>Tab</kbd> + <kbd>Shift</kbd> – move to the cell on the left side of current active cell (if exists)
+        </li>
+        <li>
+            <kbd>Home</kbd> – move to the first cell in a row
+        </li>
+        <li>
+            <kbd>End</kbd> – move to the last cell in a row
+        </li>
+        <li>
+            (<kbd>Cmd</kbd> or <kbd>Ctrl</kbd>) + <kbd>Home</kbd> – move to the first cell in a column
+        </li>
+        <li>
+            (<kbd>Cmd</kbd> or <kbd>Ctrl</kbd>) + <kbd>End</kbd> – move to the last cell in a column
+        </li>
+    </ul>
+    <h2>Selection</h2>
+    <ul>
+        <li>
+            (<kbd>Cmd</kbd> or <kbd>Ctrl</kbd>) + <kbd>A</kbd> – select all
+        </li>
+        <li>
+            <kbd>Shift</kbd> + <kbd>Arrow Up ↑</kbd> – extend selection of the cell above
+        </li>
+        <li>
+            <kbd>Shift</kbd> + <kbd>Arrow Down ↓</kbd> – extend selection of the cell underneath
+        </li>
+        <li>
+            <kbd>Shift</kbd> + <kbd>Arrow Right →</kbd> – extend selection of the cell on the right
+        </li>
+        <li>
+            <kbd>Shift</kbd> + <kbd>Arrow Left ←</kbd> – extend selection of the cell on the left
+        </li>
+        <li>
+            <kbd>Shift</kbd> + <kbd>Home</kbd> – select all cells in the row to the right including the current cell
+        </li>
+        <li>
+            <kbd>Shift</kbd> + <kbd>End</kbd> – select all cells in the row to the left including the current cell
+        </li>
+        <li>
+            (<kbd>Cmd</kbd> or <kbd>Ctrl</kbd>) + <kbd>Shift</kbd> + <kbd>Home</kbd> – select all cells in the column to the top including the current cell
+        </li>
+        <li>
+            (<kbd>Cmd</kbd> or <kbd>Ctrl</kbd>) + <kbd>Shift</kbd> + <kbd>End</kbd> – select all cells in the column to the bottom including the current cell
+        </li>
+    </ul>
+    <h2>Editing</h2>
+    <ul>
+        <li>
+            <kbd>Enter</kbd> – open/close cell editor
+        </li>
+        <li>
+            <kbd>F2</kbd> – open cell editor
+        </li>
+        <li>
+            <kbd>Esc</kbd> – cancel editing and close cell editor
+        </li>
+        <li>
+            <kbd>Backspace</kbd> – empty cell
+        </li>
+        <li>
+            <kbd>Delete</kbd> – empty cell
+        </li>
+        <li>
+            (<kbd>Cmd</kbd> or <kbd>Ctrl</kbd>) + <kbd>C</kbd> – copy cell's content
+        </li>
+        <li>
+            (<kbd>Cmd</kbd> or <kbd>Ctrl</kbd>) + <kbd>X</kbd> – cut cell's content
+        </li>
+        <li>
+            (<kbd>Cmd</kbd> or <kbd>Ctrl</kbd>) + <kbd>V</kbd> – pastle cell's content
+        </li>
+        <li>
+            (<kbd>Cmd</kbd> or <kbd>Ctrl</kbd>) + <kbd>Enter</kbd> - fill all selected cells with edited cell's value
+        </li>
+        <li>
+            (<kbd>Cmd</kbd> or <kbd>Ctrl</kbd>) + <kbd>Z</kbd> – undo
+        </li>
+        <li>
+            (<kbd>Cmd</kbd> or <kbd>Ctrl</kbd>) + <kbd>Y</kbd> – redo
+        </li>
+    </ul>
+    <h2>Context menu</h2>
+    <ul>
+        <li>
+            <kbd>Arrow Down ↓</kbd> – move to the next option in context menu
+        </li>
+        <li>
+            <kbd>Arrow Up ↑</kbd> – move to the previous option in context menu
+        </li>
+        <li>
+            <kbd>Enter</kbd> – select option from context menu
+        </li>
+    </ul>
+  {{/content}}
+
+{{/extend}}


### PR DESCRIPTION
Based on the comments in issue #68, I have done several things:

* Added insert above/below/left/right and remove row/col to 'Edit' menu so they are more obvious to new users
* Defined some additional keyboard shortcuts, but these are pretty much just 'placeholders' pending feedback (see https://github.com/theodi/comma-chameleon/issues/68#issuecomment-266245776 for discussion)
* Added docs for the HandsOnTable keyboard shortcuts in a help dialog. I haven't bothered to add the menu accelerators to this as they're already there on the menus and I reckon it just adds a second place to remember to add new ones, but I'm open to feedback on that.

This might merge conflict with PR #127 - if it does, let me know and I'll rebase.