### PR TITLE
Add cells with tab and enter

### DIFF
--- a/renderer/hot.js
+++ b/renderer/hot.js
@@ -9,6 +9,7 @@ var initialise = function(container) {
     columnSorting: true,
     contextMenu: false,
     autoRowSize: true,
+    enterBeginsEditing: false,
     afterInit: function() {
       loader.showLoader('Loading...');
     },

--- a/renderer/hot.js
+++ b/renderer/hot.js
@@ -30,7 +30,7 @@ var initialise = function(container) {
       var selection = hot.getSelected();
       next = hot.getCell(selection[0] + 1, selection[1])
       if (next == null) {
-       hot.alter('insert_row', selection[1] + 1);
+       hot.alter('insert_row', selection[0] + 1);
       }
       return {row: 1, col: 0}
     }

--- a/renderer/hot.js
+++ b/renderer/hot.js
@@ -10,6 +10,14 @@ var initialise = function(container) {
     contextMenu: false,
     autoRowSize: true,
     enterBeginsEditing: false,
+    tabMoves: function(event) {
+      var selection = hot.getSelected();
+      next = hot.getCell(selection[0], selection[1] + 1)
+      if (next == null) {
+       hot.alter('insert_col', selection[1] + 1);
+      }
+      return {row: 0, col: 1}
+    },
     afterInit: function() {
       loader.showLoader('Loading...');
     },

--- a/renderer/hot.js
+++ b/renderer/hot.js
@@ -27,10 +27,12 @@ var initialise = function(container) {
       loader.hideLoader();
     },
     enterMoves: function(event) {
-      var selection = hot.getSelected();
-      next = hot.getCell(selection[0] + 1, selection[1])
-      if (next == null) {
-       hot.alter('insert_row', selection[0] + 1);
+      if (!event.shiftKey) {
+        var selection = hot.getSelected();
+        next = hot.getCell(selection[0] + 1, selection[1])
+        if (next == null) {
+         hot.alter('insert_row', selection[0] + 1);
+        }
       }
       return {row: 1, col: 0}
     }

--- a/renderer/hot.js
+++ b/renderer/hot.js
@@ -11,10 +11,12 @@ var initialise = function(container) {
     autoRowSize: true,
     enterBeginsEditing: false,
     tabMoves: function(event) {
-      var selection = hot.getSelected();
-      next = hot.getCell(selection[0], selection[1] + 1)
-      if (next == null) {
-       hot.alter('insert_col', selection[1] + 1);
+      if (!event.shiftKey) {
+        var selection = hot.getSelected();
+        next = hot.getCell(selection[0], selection[1] + 1)
+        if (next == null) {
+         hot.alter('insert_col', selection[1] + 1);
+        }
       }
       return {row: 0, col: 1}
     },

--- a/renderer/hot.js
+++ b/renderer/hot.js
@@ -24,6 +24,14 @@ var initialise = function(container) {
     afterLoadData: function() {
       loader.hideLoader();
     },
+    enterMoves: function(event) {
+      var selection = hot.getSelected();
+      next = hot.getCell(selection[0] + 1, selection[1])
+      if (next == null) {
+       hot.alter('insert_row', selection[1] + 1);
+      }
+      return {row: 1, col: 0}
+    }
   });
   return hot;
 };

--- a/renderer/hot.js
+++ b/renderer/hot.js
@@ -32,9 +32,13 @@ var initialise = function(container) {
         next = hot.getCell(selection[0] + 1, selection[1])
         if (next == null) {
          hot.alter('insert_row', selection[0] + 1);
-        }
-      }
-      return {row: 1, col: 0}
+         return {row: 1, col: 0 - selection[1]}
+       } else {
+         return {row: 1, col: 0}
+       }
+     } else {
+       return {row: 1, col: 0}
+     }
     }
   });
   return hot;

--- a/test/renderer/file_actions_spec.js
+++ b/test/renderer/file_actions_spec.js
@@ -41,29 +41,31 @@ describe('open file (semicolon separated)', function() {
 
 describe('save file', function() {
 
-  it('saves a file', function() {
+  it('saves a file', function(done) {
     var data = "foo,bar,baz\r\n1,2,3\r\n4,5,6\r\n";
     file_actions.open(hot, data);
     file_actions.save(hot, os.tmpdir() + '/mycsv.csv');
 
     fs.readFile(os.tmpdir() + '/mycsv.csv', 'utf-8', function (err, d) {
       expect(d).to.eq(data);
+      expect(document.title).to.eq(os.tmpdir() + '/mycsv.csv');
+      done()
     });
 
-    expect(document.title).to.eq(os.tmpdir() + '/mycsv.csv');
   });
 
 });
 
 describe('convert file', function() {
 
-  it('converts a file from csv to tsv', function() {
+  it('converts a file from csv to tsv', function(done) {
     var data = "foo,bar,baz\r\n1,2,3\r\n4,5,6";
     file_actions.open(hot, data);
     file_actions.save(hot, os.tmpdir() + '/mytsv.tsv', file_actions.formats.tsv);
 
     fs.readFile(os.tmpdir() + '/mytsv.tsv', 'utf-8', function (err, d) {
       expect(d).to.eq("foo\tbar\tbaz\r\n1\t2\t3\r\n4\t5\t6\r\n");
+      done()
     });
   });
 


### PR DESCRIPTION
After some discussion in #68, I've added the ability to add rows and columns via `tab` and `enter`. When a user reaches the far right of the table and tries to `tab` into a non-existent cell, a new column is created. `enter` does a similar thing, but with rows.

@chris48s I feel like this complements #128, so if you're happy, I'll merge #128, and then we'll get this in and push a release out.