### PR TITLE
implement edit menu items using HandsOnTable API calls

### DIFF
--- a/main/menu.js
+++ b/main/menu.js
@@ -138,12 +138,16 @@ exports.menu = [
       {
         label: 'Undo',
         accelerator: 'CmdOrCtrl+Z',
-        selector: 'undo:'
+        click: function() {
+          mainWindow.webContents.send('editUndo');
+        }
       },
       {
         label: 'Redo',
         accelerator: 'Shift+CmdOrCtrl+Z',
-        selector: 'redo:'
+        click: function() {
+          mainWindow.webContents.send('editRedo');
+        }
       },
       {
         type: 'separator'
@@ -151,22 +155,31 @@ exports.menu = [
       {
         label: 'Cut',
         accelerator: 'CmdOrCtrl+X',
-        selector: 'cut:'
+        click: function() {
+          mainWindow.webContents.send('editCut');
+        }
       },
       {
         label: 'Copy',
         accelerator: 'CmdOrCtrl+C',
-        selector: 'copy:'
+        selector: 'copy:',
+        click: function() {
+          mainWindow.webContents.send('editCopy');
+        }
       },
       {
         label: 'Paste',
         accelerator: 'CmdOrCtrl+V',
-        selector: 'paste:'
+        click: function() {
+          mainWindow.webContents.send('editPaste');
+        }
       },
       {
         label: 'Select All',
         accelerator: 'CmdOrCtrl+A',
-        selector: 'selectAll:'
+        click: function() {
+          mainWindow.webContents.send('editSelectAll');
+        }
       },
       {
         type: 'separator'

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -101,6 +101,35 @@ ipc.on('validationResults', function(e, results) {
   validation.displayResults(results);
 });
 
+ipc.on('editUndo', function() {
+  if (hot.isUndoAvailable) {
+    hot.undo();
+  }
+});
+
+ipc.on('editRedo', function() {
+  if (hot.isRedoAvailable) {
+    hot.redo();
+  }
+});
+
+ipc.on('editCopy', function() {
+  hot.copyPaste.setCopyableText();
+});
+
+ipc.on('editCut', function() {
+  hot.copyPaste.setCopyableText();
+  hot.copyPaste.triggerCut();
+});
+
+ipc.on('editPaste', function() {
+  hot.copyPaste.triggerPaste();
+});
+
+ipc.on('editSelectAll', function() {
+  hot.selectCell(0, 0, (hot.countRows()-1), (hot.countCols()-1));
+});
+
 ipc.on('insertRowAbove', function() {
   hotController.insertRowAbove(false);
 });


### PR DESCRIPTION
This makes copy, cut, paste etc menu items work properly on platforms other than MacOS by removing the use of `selector`.

Closes #131