### PR TITLE
add support for custom formats

### DIFF
--- a/main/file.js
+++ b/main/file.js
@@ -27,6 +27,7 @@ function openCustom() {
     dialog = null;
   });
   ipc.once('formatSelected', function(event, data) {
+    dialog.close();
     var format = makeCustomFormat(data.separator, data.delimiter);
     openFile(format);
   });
@@ -53,6 +54,7 @@ function saveAsCustom() {
     dialog = null;
   });
   ipc.once('formatSelected', function(event, data) {
+    dialog.close();
     var format = makeCustomFormat(data.separator, data.delimiter);
     saveFileAs(format, window);
   });

--- a/main/file.js
+++ b/main/file.js
@@ -1,3 +1,14 @@
+function makeCustomFormat(separator, delimiter) {
+  // assemble a format object describing a custom format
+  return {
+    label: 'Custom',
+    filters: [],
+    options: { separator: separator, delimiter: delimiter},
+    mime_type: 'text/plain',
+    default_extension: 'txt',
+  };
+}
+
 function openFile(format) {
   Dialog.showOpenDialog({
       filters: format.filters
@@ -8,14 +19,44 @@ function openFile(format) {
   );
 }
 
-function saveFileAs(format) {
+function openCustom() {
   var window = BrowserWindow.getFocusedWindow();
+  var dialog = new BrowserWindow({width: 200, height: 400});
+  dialog.once('closed', function() {
+    ipc.removeAllListeners('formatSelected');
+    dialog = null;
+  });
+  ipc.once('formatSelected', function(event, data) {
+    var format = makeCustomFormat(data.separator, data.delimiter);
+    openFile(format);
+  });
+  dialog.loadURL('file://' + __dirname + '/../views/custom_format.html');
+}
+
+function saveFileAs(format, window) {
+  if (!window) {
+    window = BrowserWindow.getFocusedWindow();
+  }
   Dialog.showSaveDialog({ filters: format.filters }, function (fileName) {
     if (fileName === undefined) return;
     window.webContents.send('saveData', fileName, format);
     utils.enableSave();
     window.format = format;
   });
+}
+
+function saveAsCustom() {
+  var window = BrowserWindow.getFocusedWindow();
+  var dialog = new BrowserWindow({width: 200, height: 400});
+  dialog.once('closed', function() {
+    ipc.removeAllListeners('formatSelected');
+    dialog = null;
+  });
+  ipc.once('formatSelected', function(event, data) {
+    var format = makeCustomFormat(data.separator, data.delimiter);
+    saveFileAs(format, window);
+  });
+  dialog.loadURL('file://' + __dirname + '/../views/custom_format.html');
 }
 
 function saveFile() {
@@ -38,7 +79,9 @@ function readFile(fileNames, format) {
 
 module.exports = {
   openFile,
+  openCustom,
   readFile,
   saveFileAs,
+  saveAsCustom,
   saveFile
 };

--- a/main/menu.js
+++ b/main/menu.js
@@ -31,6 +31,18 @@ for (var format in file_formats) {
   }
   save_submenu.push(save_option);
 }
+open_submenu.push({
+  label: 'Custom',
+  click: function() {
+    fileActions.openCustom();
+  },
+});
+save_submenu.push({
+  label: 'Custom',
+  click: function() {
+    fileActions.saveAsCustom();
+  },
+});
 
 
 exports.menu = [

--- a/views/views-content/custom_format.html
+++ b/views/views-content/custom_format.html
@@ -1,0 +1,54 @@
+{{#extend "layout" pageTitle="Custom" containerClass="container-fluid"}}
+
+  {{#content "head" mode="append"}}
+
+    <link rel="stylesheet" href="../assets/css/datapackage.css" />
+  {{/content}}
+
+  {{#content "body"}}
+    <form id="custom-format">
+      <div class="form-wrapper">
+
+        <div class="form-group">
+          <label for="separator">Separator</label>
+          <input type="text" class="form-control" id="separator" name="separator" value=",">
+        </div>
+
+        <div class="form-group">
+          <label for="delimiter">Text Delimiter</label>
+          <input type="text" class="form-control" id="delimiter" name="delimiter" value='"'>
+        </div>
+
+      </div>
+
+      <div class="well">
+        <button id="submit" class="btn btn-default">Go</button>
+        <button id="cancel" class="btn btn-default">Cancel</button>
+      </div>
+    </form>
+  {{/content}}
+
+  {{#content "foot" mode="prepend"}}
+    <script>
+      $(function () {
+
+        $("#cancel").click(function(e) {
+          window.close()
+        });
+
+        $("#submit").click(function(e) {
+          e.preventDefault();
+          console.log($('#separator').val());
+          format = {
+            separator: $('#separator').val(),
+            delimiter: $('#delimiter').val(),
+          };
+          ipc.send('formatSelected', format);
+          window.close();
+        });
+
+      });
+    </script>
+  {{/content}}
+
+{{/extend}}

--- a/views/views-content/custom_format.html
+++ b/views/views-content/custom_format.html
@@ -38,13 +38,11 @@
 
         $("#submit").click(function(e) {
           e.preventDefault();
-          console.log($('#separator').val());
           format = {
             separator: $('#separator').val(),
             delimiter: $('#delimiter').val(),
           };
           ipc.send('formatSelected', format);
-          window.close();
         });
 
       });


### PR DESCRIPTION
This PR adds a dialog allowing the user to specify custom a separator and delimiter before opening or saving a file.

Finally all that data I have in :hankey:SV format comes into play! :)

Closes #122
