### PR TITLE
fix error on resize

### DIFF
--- a/main/utils.js
+++ b/main/utils.js
@@ -7,7 +7,7 @@ function createWindow(data, title, format) {
   // if window is not initialized with a format, default to csv
   format = typeof format !== 'undefined' ? format : file_formats.csv;
 
-  mainWindow = new BrowserWindow({width: 800, height: 600});
+  var mainWindow = new BrowserWindow({width: 800, height: 600});
   mainWindow.format = format;
 
   mainWindow.loadURL('file://' + __dirname + '/../views/index.html');


### PR DESCRIPTION
Managed to reproduce issue #95 on linux. It happens for me if I open a file, close another open window and then try to resize.
`mainWindow = null;` in `utils.js` overwrites the var `mainWindow` defined in `main.js` with `null` due to a scope error. Can someone check this definitely closes #95 on OSX.