### PR TITLE
Fix tab keyboard shortcut behaviour

### DIFF
--- a/renderer/hot.js
+++ b/renderer/hot.js
@@ -14,7 +14,7 @@ var initialise = function(container) {
       if (!event.shiftKey) {
         var selection = hot.getSelected();
         next = hot.getCell(selection[0], selection[1] + 1);
-        if (next === null) {
+        if (next === undefined) {
          hot.alter('insert_col', selection[1] + 1);
         }
       }


### PR DESCRIPTION
Steps to reproduce bug:

* Start application
* Select last cell in sheet
* Press tab
* New column won't be inserted

In PR #129, @pezholio added the ability to add a new column by pressing `tab` in the last cell of a sheet. I then accidentally broke this in https://github.com/theodi/comma-chameleon/pull/141/commits/9f96f8243a1b8d20ad2cde5619c51fd19de3c737 by chaging `if (next == null)` to a strict comparison `if (next === null)`. Previously this was working because `undefined == null` in javascript. This commit fixes that regression.