### PR TITLE
update PR template to remove auto-tag

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,5 +6,3 @@ Changes proposed in this pull request:
 -
 -
 
-> the below tags the current administrator for this repository
-@quadrophobiac


### PR DESCRIPTION
Changes proposed in this pull request:

removing the part of this which would auto-tag myself, recommend reinstating an auto tag of an allocated repository point of contact at earliest opportunity. Alternatively this Github feature could be used https://github.com/blog/2392-introducing-code-owners